### PR TITLE
Initial implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - uses: pnpm/action-setup@v2.0.1
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 7
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+  
+      - name: Run tests
+        run: pnpm test:ci
+
+      - uses: codecov/codecov-action@v2
+        name: Publish code coverage
+        with:
+          directory: coverage
+

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 # @sabl/txn
 
-**txn** is a simple, [context](https://github.com/libsabl/patterns/blob/main/patterns/context.md)-aware pattern for describing transactions - batches of operations which should all succeed together or be rolled back. The pattern can be used to run actual storage system transactions, but it is also useful for running conceptual transactions purely in a client runtime, which avoid the blocking costs of native database transactions but still allow clean up of resources if a series operations does not all succeed. 
+**txn** is a simple, [context](https://github.com/libsabl/patterns/blob/main/patterns/context.md)-aware pattern for describing transactions - batches of operations which should all succeed together or be rolled back. The pattern can be used to run actual storage system transactions, but it is also useful for running conceptual transactions purely in a client runtime, which avoid the blocking costs of native database transactions but still allow clean up of resources if a series of operations does not all succeed. 
 
-Defining these interfaces and algorithms in the abstract allows authors to write effective business logic that includes basic CRUD actions and even transaction workflows, without depending on a specific storage type, let alone a specific proprietary driver. This is in turn allows concise and testable code while avoiding over-dependence on implementation details of underlying storage choices.
+Defining these interfaces and algorithms in the abstract allows authors to write effective business logic that includes transaction workflows, without depending on a specific storage type, let alone a specific proprietary driver. This is in turn allows concise and testable code while avoiding over-dependence on implementation details of underlying storage choices.
    
 For more detail on the txn pattern, see sabl / [patterns](https://github.com/libsabl/patterns#patterns) / [txn](https://github.com/libsabl/patterns/blob/main/patterns/txn.md). 
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@commitlint/cli": "^16.3.0",
     "@commitlint/config-conventional": "^16.2.4",
-    "@faker-js/faker": "^7.3.0",
     "@jest/types": "^28.1.3",
     "@types/jest": "^28.1.5",
     "@types/node": "^17.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sabl/txn",
-  "version": "0.1.0",
+  "version": "0.1.0-a01",
   "description": "Uniform transaction lifecycle interfaces",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,7 +28,7 @@
   ],
   "keywords": [
     "sabl",
-    "storage"
+    "transaction"
   ],
   "license": "MIT",
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.3
 specifiers:
   '@commitlint/cli': ^16.3.0
   '@commitlint/config-conventional': ^16.2.4
-  '@faker-js/faker': ^7.3.0
   '@jest/types': ^28.1.3
   '@sabl/context': ^0.3.3
   '@types/jest': ^28.1.5
@@ -32,7 +31,6 @@ dependencies:
 devDependencies:
   '@commitlint/cli': 16.3.0
   '@commitlint/config-conventional': 16.2.4
-  '@faker-js/faker': 7.3.0
   '@jest/types': 28.1.3
   '@types/jest': 28.1.5
   '@types/node': 17.0.45
@@ -558,11 +556,6 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@faker-js/faker/7.3.0:
-    resolution: {integrity: sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==}
-    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
     dev: true
 
   /@humanwhocodes/config-array/0.9.5:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,401 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import {
+  Context,
+  ContextGetter,
+  ContextSetter,
+  IContext,
+  Maybe,
+  withValue,
+} from '@sabl/context';
+import {
+  ChangeSet,
+  CtxCallback,
+  Transactable,
+  Txn,
+  TxnAccessor,
+  TxnCallback,
+  TxnChangeSet,
+  TxnOptions,
+  TxnRunner,
+  IsolationLevel,
+} from './types';
+
+export {
+  IsolationLevel,
+  TxnOptions,
+  Txn,
+  Transactable,
+  CtxCallback,
+  TxnCallback,
+  TxnAccessor,
+  TxnRunner,
+  ChangeSet,
+  TxnChangeSet,
+};
+
+const ctxKeyAccessor = Symbol('TransactionAccessor');
+
+/**
+ * Set the transaction accessors on the context, so
+ * other locations can use transactions
+ * with {@link txn} or {@link txnChangeSet} without
+ * needing to know the underlying transaction type
+ */
+export function withTxnAccessor<T extends Txn>(
+  ctx: IContext,
+  accessor: TxnAccessor<T>
+): Context {
+  return withValue(ctx, ctxKeyAccessor, accessor);
+}
+
+/** Get the transaction accessor from the context */
+export function getTxnAccessor(ctx: IContext): Maybe<TxnAccessor<Txn>> {
+  return <Maybe<TxnAccessor<Txn>>>ctx.value(ctxKeyAccessor);
+}
+
+const csBuilder: Transactable<ChangeSet> = {
+  beginTxn() {
+    return Promise.resolve(new ChangeSetImpl());
+  },
+};
+
+const ctxKeyChangeSet = Symbol('ChangeSet');
+
+function getCsBuilder(): Maybe<Transactable<ChangeSet>> {
+  return csBuilder;
+}
+
+function getChangeSet(ctx: IContext): Maybe<ChangeSet> {
+  return <Maybe<ChangeSet>>ctx.value(ctxKeyChangeSet);
+}
+
+function withChangeSet(ctx: IContext, cs: ChangeSet): Context {
+  return withValue(ctx, ctxKeyChangeSet, cs);
+}
+
+const ctxKeyTxnChangeSet = Symbol('TxnChangeSet');
+
+function makeTxnCsAccessor<T extends Txn>(
+  accessor: TxnAccessor<T>
+): TxnAccessor<TxnChangeSet<T>> {
+  return {
+    getTransactable(): Maybe<Transactable<TxnChangeSet<T>>> {
+      return {
+        beginTxn() {
+          const runner = txn(accessor);
+          return Promise.resolve(new TxnChangeSetImpl(runner));
+        },
+      };
+    },
+    getTxn(ctx: IContext): Maybe<TxnChangeSet<T>> {
+      return <Maybe<TxnChangeSet<T>>>ctx.value(ctxKeyTxnChangeSet);
+    },
+    withTxn(ctx: IContext, cs: TxnChangeSet<T>): Context {
+      return withValue(ctx, ctxKeyTxnChangeSet, cs);
+    },
+  };
+}
+
+/**
+ * Create a generic transaction runner.
+ * Requires that context getters and setters
+ * were themselves already added to the context
+ * with {@link withTxnAccessor}.
+ */
+export function txn(ctx: IContext): TxnRunner<Txn>;
+
+/**
+ * Create a transaction runner for a particular
+ * transaction type. Requires context getters
+ * for the transaction type itself as well as
+ * for an interface that can start the transaction,
+ * and a context setter for the transaction type.
+ */
+export function txn<T extends Txn>(accessor: TxnAccessor<T>): TxnRunner<T>;
+
+export function txn<T extends Txn>(
+  ctxOrAccessor: IContext | TxnAccessor<T>
+): TxnRunner<T> | TxnRunner<Txn> {
+  if ('getTxn' in ctxOrAccessor) {
+    return new TxnRunnerImpl<T>(ctxOrAccessor);
+  }
+
+  const baseAccessor = getTxnAccessor(ctxOrAccessor);
+  if (baseAccessor == null) {
+    throw new Error('No transaction accessors defined on context');
+  }
+  return new TxnRunnerImpl<Txn>(baseAccessor);
+}
+
+/**
+ * Create a change set runner.
+ */
+export function changeSet(): TxnRunner<ChangeSet> {
+  return new TxnRunnerImpl({
+    getTransactable: getCsBuilder,
+    getTxn: getChangeSet,
+    withTxn: withChangeSet,
+  });
+}
+
+/**
+ * Create a a generic transaction change set
+ * runner. Requires that context getters and setters
+ * were themselves already added to the context
+ * with {@link withTxnAccessor}.
+ */
+export function txnChangeSet(ctx: IContext): TxnRunner<TxnChangeSet<Txn>>;
+
+/**
+ * Create a {@link TxnChangeSet} runner for a particular
+ * transaction type. Requires context getters
+ * for the transaction type itself as well as
+ * for an interface that can start the transaction,
+ * and a context setter for the transaction type.
+ */
+export function txnChangeSet<T extends Txn>(
+  accessor: TxnAccessor<T>
+): TxnRunner<TxnChangeSet<T>>;
+
+export function txnChangeSet<T extends Txn>(
+  ctxOrAccessor: IContext | TxnAccessor<T>
+): TxnRunner<TxnChangeSet<T>> | TxnRunner<TxnChangeSet<Txn>> {
+  if ('getTxn' in ctxOrAccessor) {
+    return new TxnRunnerImpl(makeTxnCsAccessor(ctxOrAccessor));
+  }
+
+  const baseAccessor = getTxnAccessor(ctxOrAccessor);
+  if (baseAccessor == null) {
+    throw new Error('No transaction accessors defined on context');
+  }
+  return new TxnRunnerImpl(makeTxnCsAccessor(baseAccessor));
+}
+
+function isTransactable<T extends Txn>(
+  x: T | Transactable<T>
+): x is Transactable<T> {
+  if ('beginTxn' in x) {
+    return true;
+  }
+  return false;
+}
+
+class TxnRunnerImpl<T extends Txn> implements TxnRunner<T> {
+  readonly #getTransactable: ContextGetter<Transactable<T>>;
+  readonly #getTxn: ContextGetter<T>;
+  readonly #withTxn: ContextSetter<T>;
+
+  constructor(accessor: TxnAccessor<T>) {
+    this.#getTransactable = accessor.getTransactable;
+    this.#getTxn = accessor.getTxn;
+    this.#withTxn = accessor.withTxn;
+  }
+
+  run(
+    ctx: IContext,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+  run(
+    ctx: IContext,
+    opts: TxnOptions,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+  async run(
+    ctx: IContext,
+    fnOrOpts: TxnOptions | TxnCallback<T>,
+    maybeFn?: TxnCallback<T>
+  ): Promise<void> {
+    // Resolve the overloaded arguments
+    let fn: TxnCallback<T>;
+    let opts: TxnOptions | undefined;
+
+    if (typeof fnOrOpts === 'function') {
+      fn = fnOrOpts;
+      opts = undefined;
+    } else {
+      fn = <TxnCallback<T>>maybeFn;
+      opts = fnOrOpts;
+    }
+
+    // Get the transactable from the context. Usually
+    // a database pool or connection
+    let txnSrc = this.#getTransactable(ctx);
+    if (txnSrc == null) {
+      throw new Error('No transactable source present on context');
+    }
+
+    if (fn == null) {
+      throw new Error('Missing callback function');
+    }
+
+    // Check for an existing transaction
+    const existingTxn = this.#getTxn(ctx);
+    if (existingTxn != null) {
+      if (isTransactable(existingTxn)) {
+        // Existing transaction supports nested transactions.
+        txnSrc = existingTxn;
+      } else {
+        throw new Error(
+          'There is already an open transaction, and it does not support nested transactions'
+        );
+      }
+    }
+
+    const txn = await txnSrc.beginTxn(ctx, opts);
+    const txnContext = this.#withTxn(ctx, txn);
+    try {
+      await fn(txnContext, txn);
+      await txn.commit(ctx);
+    } catch (e) {
+      await txn.rollback(ctx);
+      let errSuffix = '';
+      if (e != null) {
+        errSuffix = ': ' + String(e);
+      }
+      throw new Error(`Transaction failed${errSuffix}`, {
+        cause: e instanceof Error ? e : undefined,
+      });
+    }
+  }
+
+  in(
+    ctx: IContext,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+  in(
+    ctx: IContext,
+    opts: TxnOptions,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+  async in(
+    ctx: IContext,
+    fnOrOpts: TxnOptions | TxnCallback<T>,
+    maybeFn?: TxnCallback<T>
+  ): Promise<void> {
+    // Resolve the overloaded arguments
+    let fn: TxnCallback<T>;
+    let opts: TxnOptions | undefined;
+
+    if (typeof fnOrOpts === 'function') {
+      fn = fnOrOpts;
+      opts = undefined;
+    } else {
+      fn = <TxnCallback<T>>maybeFn;
+      opts = fnOrOpts;
+    }
+
+    // Look for an existing transaction
+    const existingTxn = this.#getTxn(ctx);
+    if (existingTxn != null) {
+      // Already an existing transaction. Run the callback
+      // using provided context and existing transaction
+      await fn(ctx, existingTxn);
+      return;
+    }
+
+    if (opts == undefined) {
+      return this.run(ctx, fn);
+    } else {
+      return this.run(ctx, opts, fn);
+    }
+  }
+}
+
+class ChangeSetImpl implements ChangeSet {
+  protected readonly commitFns: CtxCallback[] = [];
+  protected readonly rollbackFns: CtxCallback[] = [];
+  protected done = false;
+  protected ignoreStatus = false;
+
+  protected checkStatus() {
+    if (this.done) {
+      throw new Error('Change set is already committed or rolled back');
+    }
+  }
+
+  defer(fn: (ctx: IContext) => Promise<unknown> | unknown): void {
+    this.checkStatus();
+    this.commitFns.push(fn);
+  }
+
+  deferFail(fn: (ctx: IContext) => Promise<unknown> | unknown): void {
+    this.checkStatus();
+    this.rollbackFns.push(fn);
+  }
+
+  async commit(ctx: IContext): Promise<void> {
+    this.checkStatus();
+    this.done = true;
+    let ok = false;
+    try {
+      for (const fn of this.commitFns) {
+        await fn(ctx);
+      }
+      ok = true;
+    } finally {
+      this.ignoreStatus = !ok;
+    }
+  }
+
+  async rollback(ctx: IContext): Promise<void> {
+    if (this.ignoreStatus) {
+      // rollback is being called after commit() failed
+      this.ignoreStatus = false;
+    } else {
+      this.checkStatus();
+    }
+    this.done = true;
+    for (const fn of this.rollbackFns) {
+      await fn(ctx);
+    }
+  }
+}
+
+class TxnChangeSetImpl<T extends Txn>
+  extends ChangeSetImpl
+  implements TxnChangeSet<T>
+{
+  readonly #commitTxn: TxnCallback<T>[] = [];
+  readonly #txnRunner: TxnRunner<T>;
+
+  constructor(txnRunner: TxnRunner<T>) {
+    super();
+    this.#txnRunner = txnRunner;
+  }
+
+  deferTxn(fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown): void {
+    this.#commitTxn.push(fn);
+  }
+
+  async commit(ctx: IContext): Promise<void> {
+    this.checkStatus();
+    this.done = true;
+    let ok = false;
+
+    if (this.#commitTxn.length > 0) {
+      try {
+        await this.#txnRunner.run(ctx, async (txCtx, txn) => {
+          for (const fn of this.#commitTxn) {
+            await fn(txCtx, txn);
+          }
+        });
+        ok = true;
+      } finally {
+        this.ignoreStatus = !ok;
+      }
+    }
+
+    ok = false;
+    try {
+      for (const fn of this.commitFns) {
+        await fn(ctx);
+      }
+      ok = true;
+    } finally {
+      this.ignoreStatus = !ok;
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,136 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { ContextGetter, ContextSetter, IContext } from '@sabl/context';
+
+/**
+ * Various isolation levels that storage drivers may support in beginTxn.
+ * If a driver does not support a given isolation level an error may be returned.
+ */
+export enum IsolationLevel {
+  default = 1,
+  readUncommitted = 2,
+  readCommitted = 3,
+  writeCommitted = 4,
+  repeatableRead = 5,
+  snapshot = 6,
+  serializable = 7,
+  linearizable = 8,
+}
+
+/** Options to be used in beginTxn */
+export interface TxnOptions {
+  readonly isolationLevel?: IsolationLevel;
+  readonly readOnly?: boolean;
+}
+
+/** An abstract transaction that can be committed or rolled back */
+export interface Txn {
+  /** Commit all pending operations */
+  commit(ctx: IContext): Promise<void>;
+
+  /** Rollback all pending operations. */
+  rollback(ctx: IContext): Promise<void>;
+}
+
+/** An interface that can start a transaction of a given type */
+export interface Transactable<T extends Txn> {
+  beginTxn(ctx: IContext, opts?: TxnOptions): Promise<T>;
+}
+
+/** A simple asynchronous callback which accepts a context */
+export type CtxCallback = (ctx: IContext) => Promise<unknown> | unknown;
+
+/** An asynchronous callback which accepts a context and a transaction */
+export type TxnCallback<T extends Txn> = (
+  ctx: IContext,
+  txn: T
+) => Promise<unknown> | unknown;
+
+/**
+ * A bundle of context getters and setters
+ * that facilitates running transactions
+ * of a given type.
+ */
+export interface TxnAccessor<T extends Txn> {
+  getTransactable: ContextGetter<Transactable<T>>;
+  getTxn: ContextGetter<T>;
+  withTxn: ContextSetter<T>;
+}
+
+/** Abstract transaction runner */
+export interface TxnRunner<T extends Txn> {
+  /**
+   * Run a callback in a new transaction. If the callback
+   * succeeds, commit the transaction. If it fails,
+   * rollback the transaction. This method will fail
+   * if there is already a transaction on the context
+   * and it does not support nested transactions.
+   */
+  run(
+    ctx: IContext,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+  run(
+    ctx: IContext,
+    opts: TxnOptions,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+
+  /**
+   * Run a callback in a transaction. If there is
+   * already a transaction in `ctx`, use it. If not,
+   * run and complete a new transaction as in `run()`.
+   */
+  in(
+    ctx: IContext,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+  in(
+    ctx: IContext,
+    opts: TxnOptions,
+    fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown
+  ): Promise<void>;
+}
+
+/**
+ * A change set is a client-side transaction which
+ * supports scheduling callbacks to be executed in
+ * series. When the change set is committed, all
+ * the deferred callbacks are executed in series.
+ * If any of them rejects, then any failure callbacks
+ * scheduled with `deferFail` are executed.
+ */
+export interface ChangeSet extends Txn {
+  /** Defer a callback be executed on commit. */
+  defer(fn: (ctx: IContext) => Promise<unknown> | unknown): void;
+
+  /** Defer a callback to be executed on rollback. */
+  deferFail(fn: (ctx: IContext) => Promise<unknown> | unknown): void;
+
+  /** Execute the deferred callbacks */
+  commit(ctx: IContext): Promise<void>;
+
+  /** Cancel execution of any further `defer` callbacks
+   * and executed any scheduled `deferFail` callbacks. */
+  rollback(ctx: IContext): Promise<void>;
+}
+
+/**
+ * A {@link ChangeSet} that can also schedule callbacks
+ * to be executed within a true underlying transaction.
+ * When the changeset is committed, first the a transaction
+ * is opened and all transaction callbacks are executed.
+ * Any non-transaction callbacks registered with `defer`
+ * are executed after the transactions is successfully
+ * committed.
+ *
+ * The `deferFail` callbacks are invoked if the
+ * transaction fails and is rolled back, or if
+ * any of the non-transaction callbacks rejects.
+ */
+export interface TxnChangeSet<T extends Txn> extends ChangeSet {
+  /** Defer a callback be executed within an underlying transaction. */
+  deferTxn(fn: (ctx: IContext, txn: T) => Promise<unknown> | unknown): void;
+}

--- a/test/change-set.spec.ts
+++ b/test/change-set.spec.ts
@@ -1,0 +1,199 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { ChangeSet, changeSet, Txn } from '$';
+import { Context, IContext } from '@sabl/context';
+
+type RunCallback<T extends Txn> = (
+  ctx: IContext,
+  fn: (ctx: IContext, txn: T) => void | Promise<void>
+) => Promise<void>;
+
+function changeSetTests(fnRunTxn: RunCallback<ChangeSet>): void {
+  it('defers actions until commit', async () => {
+    const stack: string[] = [];
+
+    await fnRunTxn(Context.background, (_, cs) => {
+      cs.defer(() => stack.push('a'));
+      cs.defer(() => stack.push('b'));
+      cs.defer(() => stack.push('c'));
+
+      // Changes not yet committed
+      expect(stack).toEqual([]);
+    });
+
+    // Now changes are committed
+    expect(stack).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not execute any if rolled back', async () => {
+    const stack: string[] = [];
+    const failMsgs: string[] = [];
+
+    await expect(() =>
+      fnRunTxn(Context.background, (_, cs) => {
+        cs.defer(() => stack.push('a'));
+        cs.defer(() => stack.push('b'));
+        cs.defer(() => stack.push('c'));
+
+        cs.deferFail(() => failMsgs.push('failed1'));
+        cs.deferFail(() => failMsgs.push('failed2'));
+
+        // Changes not yet committed
+        expect(stack).toEqual([]);
+
+        throw new Error('Rolling back on purpose');
+      })
+    ).rejects.toThrow('Rolling back on purpose');
+
+    // No defer callbacks were run
+    expect(stack).toEqual([]);
+
+    // deferFail callbacks were run
+    expect(failMsgs).toEqual(['failed1', 'failed2']);
+  });
+
+  it('runs deferFail callbacks', async () => {
+    const stack: string[] = [];
+    const msgStack: string[] = [];
+
+    await expect(() =>
+      fnRunTxn(Context.background, (_, cs) => {
+        cs.defer(() => {
+          stack.push('a');
+          msgStack.push('Pushed a');
+        });
+        cs.deferFail(() => {
+          stack.splice(stack.indexOf('a'), 1);
+          msgStack.push('Spliced out a');
+        });
+
+        cs.defer(() => {
+          stack.push('b');
+          msgStack.push('Pushed b');
+        });
+        cs.deferFail(() => {
+          stack.splice(stack.indexOf('b'), 1);
+          msgStack.push('Spliced out b');
+        });
+
+        cs.defer(() => {
+          throw new Error('Rolling back on purpose');
+        });
+
+        cs.defer(() => {
+          stack.push('c');
+          msgStack.push('Pushed c');
+        });
+        cs.deferFail(() => {
+          stack.splice(stack.indexOf('c'), 1);
+          msgStack.push('Spliced out c');
+        });
+
+        // Changes not yet committed
+        expect(stack).toEqual([]);
+      })
+    ).rejects.toThrow('Rolling back on purpose');
+
+    // Net effect is nothing on stack
+    expect(stack).toEqual([]);
+
+    // But we have evidence of what actually happened
+    expect(msgStack).toEqual([
+      'Pushed a',
+      'Pushed b',
+      'Spliced out a',
+      'Spliced out b',
+      'Spliced out c',
+    ]);
+  });
+
+  it('rejects attempts to commit or rollback multiple times', async () => {
+    const stack: string[] = [];
+
+    await expect(() =>
+      fnRunTxn(Context.background, async (ctx, cs) => {
+        cs.defer(() => {
+          stack.push('a');
+        });
+        cs.deferFail(() => {
+          stack.splice(stack.indexOf('a'), 1);
+        });
+
+        cs.defer(() => {
+          stack.push('b');
+        });
+        cs.deferFail(() => {
+          stack.splice(stack.indexOf('b'), 1);
+        });
+
+        cs.defer(() => {
+          stack.push('c');
+        });
+        cs.deferFail(() => {
+          stack.splice(stack.indexOf('c'), 1);
+        });
+
+        await cs.commit(ctx);
+
+        // Changes committed now
+        expect(stack).toEqual(['a', 'b', 'c']);
+      })
+    ).rejects.toThrow('Change set is already committed or rolled back');
+
+    // Changes really were committed: Error was in calling commit twice
+    expect(stack).toEqual(['a', 'b', 'c']);
+  });
+}
+
+describe('changeSet', () => {
+  const csRunner = changeSet();
+
+  describe('run', () => {
+    changeSetTests(csRunner.run.bind(csRunner));
+
+    it('rejects nested transaction', async () => {
+      const stack: string[] = ['a', 'b'];
+      const ctxRoot = Context.background;
+
+      await expect(() =>
+        csRunner.run(ctxRoot, async (ctxOuter, csOuter) => {
+          csOuter.defer(() => stack.push('c'));
+
+          await csRunner.run(ctxOuter, async (ctxInner, csInner) => {
+            csInner.defer(() => stack.push('c'));
+          });
+        })
+      ).rejects.toThrow('does not support nested transactions');
+    });
+  });
+
+  describe('in', () => {
+    changeSetTests(csRunner.in.bind(csRunner));
+
+    it('reuses existing changeSet', async () => {
+      const stack: string[] = ['a', 'b'];
+      const ctxRoot = Context.background;
+
+      await csRunner.in(ctxRoot, async (ctxOuter, cs) => {
+        await csRunner.in(ctxOuter, async (ctxInner, csInner) => {
+          // Same context and txn
+          expect(ctxInner).toBe(ctxOuter);
+          expect(csInner).toBe(cs);
+
+          csInner.defer(() => stack.push('c'));
+
+          // Not yet committed
+          expect(stack).toEqual(['a', 'b']);
+        });
+
+        // Still not committed
+        expect(stack).toEqual(['a', 'b']);
+      });
+
+      // Automatically committed
+      expect(stack).toEqual(['a', 'b', 'c']);
+    });
+  });
+});

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -1,0 +1,430 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { Transactable, Txn, TxnAccessor, TxnOptions } from '$';
+import { PromiseHandle } from '$test/lib/util';
+import { Canceler, Context, IContext, Maybe, withValue } from '@sabl/context';
+
+export interface StackApi {
+  push(ctx: IContext, val: unknown): Promise<number>;
+  peek(ctx: IContext): Promise<unknown>;
+  pop(ctx: IContext): Promise<unknown>;
+}
+
+export interface StackTxn extends Txn, StackApi {}
+
+export interface StackTransactable extends Transactable<StackTxn> {
+  beginTxn(ctx: IContext, opts?: TxnOptions): Promise<StackTxn>;
+}
+
+export interface StackConn extends StackApi, StackTransactable {
+  close(): Promise<void>;
+}
+
+export interface StackPool extends StackApi, StackTransactable {
+  conn(ctx: IContext): Promise<StackConn>;
+  close(): Promise<void>;
+}
+
+const ctxKeyStackConn = Symbol('StackConn');
+const ctxKeyStackTxn = Symbol('StackTxn');
+
+/** Set the stack pool or connection on the context */
+export function withStackConn(ctx: IContext, con: StackTransactable): Context {
+  return withValue(ctx, ctxKeyStackConn, con);
+}
+
+/** Get the stack pool or connection from the context */
+export function getStackConn(ctx: IContext): Maybe<StackTransactable> {
+  return <Maybe<StackTransactable>>ctx.value(ctxKeyStackConn);
+}
+
+/** Set the stack transaction on the context */
+export function withStackTxn(ctx: IContext, txn: StackTxn): Context {
+  return withValue(ctx, ctxKeyStackTxn, txn);
+}
+
+/** Get the stack transaction from the context */
+export function getStackTxn(ctx: IContext): Maybe<StackTxn> {
+  return <Maybe<StackTxn>>ctx.value(ctxKeyStackTxn);
+}
+
+/**
+ * Context accessor methods for the StackApi
+ * compatible with the [`txn()` API](https://npmjs.com/package/@sabl/txn#api) from
+ * [`@sabl/txn`](https://npmjs.com/package/@sabl/txn)
+ * */
+export const StackCtxAccessor: TxnAccessor<StackTxn> = {
+  getTransactable: getStackConn,
+  getTxn: getStackTxn,
+  withTxn: withStackTxn,
+};
+
+export interface StackConnOptions {
+  nestedTxn?: boolean;
+}
+
+interface StackOp {
+  op: 'push' | 'pop' | 'txn';
+  val?: unknown;
+  txn?: MemStackTxn;
+}
+
+interface TxnRunner {
+  _txnDone(txn: MemStackTxn): null | Promise<void>;
+}
+
+class MemStackTxn implements StackTxn {
+  readonly #con: TxnRunner & StackApi;
+  readonly #snap: unknown[];
+  readonly #ops: StackOp[] = [];
+  readonly #readonly: boolean;
+  readonly #connOpts: StackConnOptions;
+  readonly #txns: MemStackTxn[] = [];
+
+  #done = false;
+  #clr?: Canceler;
+  #onCancel: null | (() => void) = null;
+  #closeResolve: PromiseHandle<void> | null = null;
+
+  constructor(
+    con: TxnRunner & StackApi,
+    stack: unknown[],
+    opts: TxnOptions | undefined,
+    clr: Canceler | null,
+    connOpts?: StackConnOptions
+  ) {
+    this.#con = con;
+    this.#snap = stack.concat();
+    this.#readonly = (opts || {}).readOnly === true;
+    this.#connOpts = connOpts || {};
+
+    if (clr != null) {
+      this.#clr = clr;
+      clr.onCancel(
+        (this.#onCancel = this.#cancel.bind(this, Context.background))
+      );
+    }
+
+    if (this.#connOpts.nestedTxn === true) {
+      Object.defineProperty(this, 'beginTxn', { value: this.#beginTxn });
+    }
+  }
+
+  #beginTxn(ctx: IContext, opts?: TxnOptions | undefined): Promise<StackTxn> {
+    this.#checkStatus();
+    const txn = new MemStackTxn(
+      this,
+      this.#snap,
+      opts,
+      ctx.canceler,
+      this.#connOpts
+    );
+    this.#txns.push(txn);
+    this.#ops.push({ op: 'txn', txn });
+    return Promise.resolve(txn);
+  }
+
+  #cancel(ctx: IContext) {
+    if (this.#onCancel) {
+      this.#clr?.off(this.#onCancel);
+      this.#onCancel = null;
+    }
+    if (!this.#done) {
+      this.rollback(ctx);
+    }
+  }
+
+  #checkStatus(mod = false) {
+    if (this.#done) {
+      throw new Error('Transaction is already complete');
+    }
+    if (mod && this.#readonly) {
+      throw new Error('Cannot push or pop: Transaction is read-only');
+    }
+  }
+
+  #complete(ctx: IContext): Promise<void> {
+    this.#cancel(ctx);
+    return this.#con._txnDone(this) || Promise.resolve();
+  }
+
+  async commit(ctx: IContext): Promise<void> {
+    this.#checkStatus();
+    this.#done = true;
+
+    for (const op of this.#ops) {
+      if (op.op == 'pop') {
+        await this.#con.pop(ctx);
+      } else if (op.op == 'push') {
+        await this.#con.push(ctx, op.val);
+      } else if (op.op == 'txn') {
+        const txn = op.txn;
+        if (txn != null && !txn.#done) {
+          await txn.commit(ctx);
+        }
+      }
+    }
+
+    return this.#complete(ctx);
+  }
+
+  async rollback(ctx: IContext): Promise<void> {
+    this.#checkStatus();
+    this.#done = true;
+
+    if (this.#txns.length > 0) {
+      const promises = [];
+      for (const txn of this.#txns) {
+        promises.push(promises.push(txn.rollback(ctx)));
+      }
+      this.#txns.splice(0, this.#txns.length);
+      await Promise.all(promises);
+    }
+    return this.#complete(ctx);
+  }
+
+  push(ctx: IContext, val: unknown): Promise<number> {
+    this.#checkStatus(true);
+    this.#ops.push({ op: 'push', val });
+    this.#snap.push(val);
+    return Promise.resolve(this.#snap.length);
+  }
+
+  pop(/* ctx: IContext */): Promise<unknown> {
+    this.#checkStatus(true);
+    this.#ops.push({ op: 'pop' });
+    return Promise.resolve(this.#snap.pop());
+  }
+
+  peek(/* ctx: IContext */): Promise<unknown> {
+    this.#checkStatus();
+    return Promise.resolve(this.#snap[this.#snap.length - 1]);
+  }
+
+  _txnDone(txn: MemStackTxn): null {
+    const ix = this.#txns.indexOf(txn);
+    if (ix < 0) {
+      return null;
+    }
+
+    this.#txns.splice(ix, 1);
+
+    if (this.#txns.length == 0) {
+      if (this.#closeResolve != null) {
+        if (this.#txns.length > 0) {
+          // Still a child transaction open.
+          return null;
+        }
+        // No more child transactions open.
+        return null;
+      }
+    }
+
+    return null;
+  }
+}
+
+class MemStackConn implements StackConn {
+  readonly #stack: unknown[];
+  readonly #txns: MemStackTxn[] = [];
+  readonly #pool: MemStackPool;
+  readonly #opts: StackConnOptions;
+
+  #keepOpen = false;
+  #closed = false;
+  #closeResolve: PromiseHandle<void> | null = null;
+
+  constructor(
+    pool: MemStackPool,
+    stack: unknown[],
+    keepOpen: boolean,
+    opts?: StackConnOptions
+  ) {
+    this.#pool = pool;
+    this.#stack = stack;
+    this.#keepOpen = keepOpen;
+    this.#opts = opts || {};
+  }
+
+  #checkStatus() {
+    if (this.#closed) {
+      throw new Error('Connection is closed');
+    }
+  }
+
+  close(): Promise<void> {
+    this.#checkStatus();
+    this.#closed = true;
+    for (const txnId in this.#txns) {
+      // Still a transaction open.
+      return (this.#closeResolve = new PromiseHandle<void>()).promise;
+    }
+    this.#pool._release(this);
+    return Promise.resolve();
+  }
+
+  beginTxn(ctx: IContext, opts?: TxnOptions | undefined): Promise<StackTxn> {
+    this.#checkStatus();
+    const txn = new MemStackTxn(
+      this,
+      this.#stack,
+      opts,
+      ctx.canceler,
+      this.#opts
+    );
+    this.#txns.push(txn);
+    return Promise.resolve(txn);
+  }
+
+  push(ctx: IContext, val: unknown): Promise<number> {
+    this.#checkStatus();
+    this.#stack.push(val);
+    return Promise.resolve(this.#stack.length);
+  }
+
+  pop(/* ctx: IContext */): Promise<unknown> {
+    this.#checkStatus();
+    return Promise.resolve(this.#stack.pop());
+  }
+
+  peek(/* ctx: IContext */): Promise<unknown> {
+    this.#checkStatus();
+    return Promise.resolve(this.#stack[this.#stack.length - 1]);
+  }
+
+  _txnDone(txn: MemStackTxn): null | Promise<void> {
+    const ix = this.#txns.indexOf(txn);
+    if (ix < 0) {
+      return null;
+    }
+
+    this.#txns.splice(ix, 1);
+
+    if (this.#txns.length == 0) {
+      if (this.#closeResolve != null) {
+        if (this.#txns.length > 0) {
+          // Still a transaction open.
+          return null;
+        }
+        // No more transactions open.
+        // Release the connection and resolve the close call
+        this.#pool._release(this);
+        this.#closeResolve.resolve();
+        return null;
+      }
+
+      if (!this.#keepOpen) {
+        return this.close();
+      }
+    }
+
+    return null;
+  }
+}
+
+class MemStackPool implements StackPool {
+  readonly #stack: unknown[];
+  readonly #active: MemStackConn[] = [];
+  readonly #opts: StackConnOptions;
+  #closed = false;
+  #waitClose: PromiseHandle<void> | null = null;
+
+  constructor(stack: unknown[], opts?: StackConnOptions) {
+    this.#stack = stack;
+    this.#opts = opts || {};
+  }
+
+  #checkStatus() {
+    if (this.#closed) {
+      throw new Error('Pool is closed');
+    }
+  }
+
+  conn(/* ctx: IContext */): Promise<StackConn> {
+    this.#checkStatus();
+    return Promise.resolve(
+      new MemStackConn(this, this.#stack, true, this.#opts)
+    );
+  }
+
+  close(): Promise<void> {
+    if (this.#closed) {
+      return this.#waitClose?.promise || Promise.resolve();
+    }
+
+    this.#closed = true;
+    if (this.#active.length > 0) {
+      const p = (this.#waitClose = new PromiseHandle<void>()).promise;
+      for (const c of this.#active) {
+        // Signal all connections to close
+        // NOT awaiting here. We want to signal
+        // all connections immediately
+        c.close();
+      }
+      return p;
+    }
+
+    return Promise.resolve();
+  }
+
+  beginTxn(ctx: IContext, opts?: TxnOptions | undefined): Promise<StackTxn> {
+    this.#checkStatus();
+    const con = new MemStackConn(this, this.#stack, false, this.#opts);
+    return con.beginTxn(ctx, opts);
+  }
+
+  async push(ctx: IContext, val: unknown): Promise<number> {
+    this.#checkStatus();
+    const con = await this.conn();
+    try {
+      return con.push(ctx, val);
+    } finally {
+      con.close();
+    }
+  }
+
+  async pop(ctx: IContext): Promise<unknown> {
+    this.#checkStatus();
+    const con = await this.conn();
+    try {
+      return con.pop(ctx);
+    } finally {
+      con.close();
+    }
+  }
+
+  async peek(ctx: IContext): Promise<unknown> {
+    this.#checkStatus();
+    const con = await this.conn();
+    try {
+      return con.peek(ctx);
+    } finally {
+      con.close();
+    }
+  }
+
+  _release(con: MemStackConn): void {
+    const ix = this.#active.indexOf(con);
+    if (ix < 0) {
+      return;
+    }
+    this.#active.splice(ix, 1);
+
+    if (this.#active.length == 0) {
+      const wc = this.#waitClose;
+      if (wc != null) {
+        this.#waitClose = null;
+        wc.resolve();
+      }
+    }
+  }
+}
+
+export function openStackPool(
+  stack: unknown[],
+  opts?: StackConnOptions
+): StackPool {
+  return new MemStackPool(stack, opts);
+}

--- a/test/lib/util.ts
+++ b/test/lib/util.ts
@@ -1,0 +1,53 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+export function hasFlag<T extends number>(flags: T, flag: T): boolean {
+  return (flags & flag) === flag;
+}
+
+export type FnReject = (reason: unknown) => void;
+export type FnResolve<T> = (value: T | PromiseLike<T>) => void;
+
+export class PromiseHandle<T> {
+  constructor();
+  constructor(p: Promise<T>, rslv: FnResolve<T>, rjct: FnReject);
+  constructor(p?: Promise<T>, rslv?: FnResolve<T>, rjct?: FnReject) {
+    if (p != null) {
+      this.#promise = p;
+      this.#reject = rjct!;
+      this.#resolve = rslv!;
+      return;
+    }
+
+    let res: FnResolve<T>;
+    let rej: FnReject;
+
+    this.#promise = new Promise<T>((resolve, reject) => {
+      res = resolve;
+      rej = reject;
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.#resolve = res!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.#reject = rej!;
+  }
+
+  readonly #resolve: FnResolve<T>;
+  resolve(value: T | PromiseLike<T>): void {
+    return this.#resolve(value);
+  }
+
+  readonly #reject: FnReject;
+  reject(reason?: unknown): void {
+    return this.#reject(reason);
+  }
+
+  readonly #promise: Promise<T>;
+  get promise(): Promise<T> {
+    return this.#promise;
+  }
+}

--- a/test/txn-change-set.spec.ts
+++ b/test/txn-change-set.spec.ts
@@ -1,0 +1,186 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { txnChangeSet, withTxnAccessor } from '$';
+import { Context } from '@sabl/context';
+import { openStackPool, StackCtxAccessor, withStackConn } from './fixtures';
+
+describe('txnChangeSet', () => {
+  const txnCsRunner = txnChangeSet(StackCtxAccessor);
+
+  describe('commit', () => {
+    it('commits both txn and non-txn callbacks', async () => {
+      const stack: unknown[] = ['a', 'b'];
+      const pool = openStackPool(stack);
+      const ctxRoot = Context.value(withStackConn, pool);
+
+      const msgLog: string[] = [];
+      const errLog: string[] = [];
+
+      await txnCsRunner.run(ctxRoot, (ctx, cs) => {
+        cs.deferTxn(async (ctx, txn) => {
+          await txn.push(ctx, 'c');
+        });
+
+        cs.defer(() => msgLog.push('Pushed c!'));
+
+        cs.deferFail(() => errLog.push('Called error callback'));
+
+        // No callbacks executed yet
+        expect(stack).toEqual(['a', 'b']);
+        expect(msgLog).toEqual([]);
+        expect(errLog).toEqual([]);
+      });
+
+      // Txn was committed:
+      expect(stack).toEqual(['a', 'b', 'c']);
+
+      // Non-txn callback was invoked:
+      expect(msgLog).toEqual(['Pushed c!']);
+
+      // Error callback was NOT invoked:
+      expect(errLog).toEqual([]);
+    });
+
+    it('does not open a transaction if no txn callbacks', async () => {
+      const stack: unknown[] = ['a', 'b'];
+      const pool = openStackPool(stack);
+      const ctxRoot = Context.value(withStackConn, pool);
+
+      const msgLog: string[] = [];
+      const errLog: string[] = [];
+
+      // Booby-trap the beginTxn method!
+      pool.beginTxn = function () {
+        throw new Error('No transactions for you!');
+      };
+
+      await expect(() => pool.beginTxn(ctxRoot)).toThrow(
+        'No transactions for you!'
+      );
+
+      await txnCsRunner.run(ctxRoot, (ctx, cs) => {
+        cs.defer((ctx) => pool.push(ctx, 'c'));
+
+        cs.defer(() => msgLog.push('Pushed c!'));
+
+        cs.deferFail(() => errLog.push('Called error callback'));
+
+        // No callbacks executed yet
+        expect(stack).toEqual(['a', 'b']);
+        expect(msgLog).toEqual([]);
+        expect(errLog).toEqual([]);
+      });
+
+      // pool.push callback was run:
+      expect(stack).toEqual(['a', 'b', 'c']);
+
+      // Non-txn callback was invoked:
+      expect(msgLog).toEqual(['Pushed c!']);
+
+      // Error callback was NOT invoked:
+      expect(errLog).toEqual([]);
+    });
+  });
+
+  describe('rollback', () => {
+    it('within txn rolls back underlying transaction', async () => {
+      const stack: unknown[] = ['a', 'b'];
+      const pool = openStackPool(stack);
+      const ctxRoot = Context.value(withStackConn, pool);
+
+      const msgLog: string[] = [];
+      const errLog: string[] = [];
+
+      await expect(
+        txnCsRunner.run(ctxRoot, (_, cs) => {
+          cs.deferTxn(async (ctx, txn) => {
+            await txn.push(ctx, 'c');
+
+            const v = await txn.peek(ctx);
+            expect(v).toBe('c');
+          });
+
+          cs.deferTxn(() => {
+            throw new Error('Failing on purpose');
+          });
+
+          cs.defer(() => msgLog.push('Pushed c!'));
+
+          cs.deferFail(() => errLog.push('Called error callback'));
+
+          // No callbacks executed yet
+          expect(stack).toEqual(['a', 'b']);
+          expect(msgLog).toEqual([]);
+          expect(errLog).toEqual([]);
+        })
+      ).rejects.toThrow('Failing on purpose');
+
+      // Txn was NOT committed:
+      expect(stack).toEqual(['a', 'b']);
+
+      // Non-txn callback was NOT invoked:
+      expect(msgLog).toEqual([]);
+
+      // Error callback WAS invoked:
+      expect(errLog).toEqual(['Called error callback']);
+    });
+
+    it('after txn cannot roll back txn', async () => {
+      const stack: unknown[] = ['a', 'b'];
+      const pool = openStackPool(stack);
+      const ctxRoot = Context.value(withStackConn, pool);
+
+      const msgLog: string[] = [];
+      const errLog: string[] = [];
+
+      await expect(
+        txnCsRunner.run(ctxRoot, (_, cs) => {
+          cs.deferTxn(async (ctx, txn) => {
+            await txn.push(ctx, 'c');
+
+            const v = await txn.peek(ctx);
+            expect(v).toBe('c');
+          });
+
+          cs.defer(() => {
+            throw new Error('Failing on purpose');
+          });
+
+          cs.defer(() => msgLog.push('Pushed c!'));
+
+          cs.deferFail(() => errLog.push('Called error callback'));
+
+          // No callbacks executed yet
+          expect(stack).toEqual(['a', 'b']);
+          expect(msgLog).toEqual([]);
+          expect(errLog).toEqual([]);
+        })
+      ).rejects.toThrow('Failing on purpose');
+
+      // Txn WAS committed:
+      expect(stack).toEqual(['a', 'b', 'c']);
+
+      // Second non-txn callback was NOT invoked:
+      expect(msgLog).toEqual([]);
+
+      // Error callback WAS invoked:
+      expect(errLog).toEqual(['Called error callback']);
+    });
+  });
+
+  describe('context accessors', () => {
+    it('gets accessors from context', () => {
+      const rootCtx = Context.value(withTxnAccessor, StackCtxAccessor);
+      const runner = txnChangeSet(rootCtx);
+      expect(runner.run).toBeInstanceOf(Function);
+    });
+
+    it('fails if no accessors set', () => {
+      expect(() => txnChangeSet(Context.background)).toThrow(
+        'No transaction accessors defined on context'
+      );
+    });
+  });
+});

--- a/test/txn.spec.ts
+++ b/test/txn.spec.ts
@@ -1,0 +1,260 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {
+  Txn,
+  txn,
+  TxnCallback,
+  TxnOptions,
+  TxnRunner,
+  withTxnAccessor,
+} from '$';
+import { Context, IContext } from '@sabl/context';
+import {
+  openStackPool,
+  StackCtxAccessor,
+  StackTxn,
+  withStackConn,
+} from './fixtures';
+
+type RunCallback<T extends Txn> = (
+  ctx: IContext,
+  fn: (ctx: IContext, txn: T) => Promise<void>
+) => Promise<void>;
+
+function testRunTxn(fnRunTxn: RunCallback<StackTxn>): void {
+  it('runs operations inside a transaction', async () => {
+    const stack: unknown[] = [];
+    stack.push('a', 'b');
+
+    const pool = openStackPool(stack);
+    const ctxRoot = Context.value(withStackConn, pool);
+
+    await fnRunTxn(ctxRoot, async (ctx, txn) => {
+      await txn.push(ctx, 'c');
+
+      // Not yet committed
+      expect(stack).toEqual(['a', 'b']);
+    });
+
+    // Automatically committed
+    expect(stack).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles throw non-error', async () => {
+    const pool = openStackPool([]);
+    const ctxRoot = Context.value(withStackConn, pool);
+
+    // Actual error thrown is provided in cause
+    let err: Error | null = null;
+    const innerError = new Error('I am a real error');
+    try {
+      await fnRunTxn(ctxRoot, () => {
+        throw innerError;
+      });
+    } catch (e) {
+      err = <Error>e;
+    }
+    expect(err!.cause).toBe(innerError);
+    expect(err?.message).toEqual(
+      'Transaction failed: Error: I am a real error'
+    );
+
+    // Non-error is stringified
+    await expect(() =>
+      fnRunTxn(ctxRoot, () => {
+        throw 'Not an error object';
+      })
+    ).rejects.toThrow('Transaction failed: Not an error object');
+
+    // Null is ignored
+    await expect(() =>
+      fnRunTxn(ctxRoot, () => {
+        throw null;
+      })
+    ).rejects.toThrow('Transaction failed');
+  });
+
+  it('uses provided options', async () => {
+    const stack: unknown[] = [];
+    stack.push('a', 'b');
+
+    const pool = openStackPool(stack);
+    const ctxRoot = Context.value(withStackConn, pool);
+
+    const runWithOpts = <
+      (
+        ctx: IContext,
+        opts: TxnOptions,
+        cb: TxnCallback<StackTxn>
+      ) => Promise<void>
+    >(<unknown>fnRunTxn);
+
+    await expect(() =>
+      runWithOpts(ctxRoot, { readOnly: true }, async (ctx, txn) => {
+        await txn.push(ctx, 'c');
+
+        // Not yet committed
+        expect(stack).toEqual(['a', 'b']);
+      })
+    ).rejects.toThrow('Transaction is read-only');
+
+    // Not committed
+    expect(stack).toEqual(['a', 'b']);
+  });
+
+  it('rolls back on error', async () => {
+    const stack: unknown[] = [];
+    stack.push('a', 'b');
+
+    const pool = openStackPool(stack);
+    const ctxRoot = Context.value(withStackConn, pool);
+
+    await expect(async () =>
+      fnRunTxn(ctxRoot, async (ctx, txn) => {
+        await txn.push(ctx, 'c');
+
+        // Within txn, tail is 'c'
+        const val = await txn.peek(ctx);
+        expect(val).toBe('c');
+
+        throw new Error('Failing on purpose');
+      })
+    ).rejects.toThrow();
+
+    // Changes were not committed
+    expect(stack).toEqual(['a', 'b']);
+  });
+
+  it('throws if there is no storage api', async () => {
+    const ctxRoot = Context.background;
+
+    await expect(() =>
+      fnRunTxn(ctxRoot, () => Promise.resolve())
+    ).rejects.toThrow('No transactable source present on context');
+  });
+
+  it('throws if no callback', async () => {
+    const stack: unknown[] = [];
+    stack.push('a', 'b');
+
+    const pool = openStackPool(stack);
+    const ctxRoot = Context.value(withStackConn, pool);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await expect(() => fnRunTxn(ctxRoot, null!)).rejects.toThrow(
+      'Missing callback function'
+    );
+  });
+}
+
+function testTxnModes(txnRunner: TxnRunner<StackTxn>): void {
+  describe('run', () => {
+    testRunTxn(txnRunner.run.bind(txnRunner));
+
+    it('rejects nested transaction', async () => {
+      const stack: unknown[] = [];
+      stack.push('a', 'b');
+
+      const pool = openStackPool(stack);
+      const ctxRoot = Context.value(withStackConn, pool);
+
+      await expect(() =>
+        txnRunner.run(ctxRoot, async (ctxOuter, txnOuter) => {
+          await txnOuter.push(ctxOuter, 'c');
+
+          await txnRunner.run(ctxOuter, async (ctxInner, txnInner) => {
+            await txnInner.push(ctxInner, 'd');
+          });
+        })
+      ).rejects.toThrow('does not support nested transactions');
+    });
+
+    it('supports nested transaction', async () => {
+      const stack: unknown[] = [];
+      stack.push('a', 'b');
+
+      const pool = openStackPool(stack, { nestedTxn: true });
+      const ctxRoot = Context.value(withStackConn, pool);
+
+      await txnRunner.run(ctxRoot, async (ctxOuter, txnOuter) => {
+        await txnOuter.push(ctxOuter, 'c');
+
+        await txnRunner.run(ctxOuter, async (ctxInner, txnInner) => {
+          await txnInner.push(ctxInner, 'd');
+
+          // Last item is visible within inner transaction
+          const last = await txnInner.peek(ctxInner);
+          expect(last).toBe('d');
+
+          // Within outer transaction last item is still 'c'
+          const lastOuter = await txnOuter.peek(ctxOuter);
+          expect(lastOuter).toBe('c');
+
+          // Within base transaction last item is still 'b'
+          const lastBase = await pool.peek(ctxOuter);
+          expect(lastBase).toBe('b');
+        });
+
+        // Now inner is committed to outer:
+        // Within outer transaction last item is now 'd'
+        const lastOuter = await txnOuter.peek(ctxOuter);
+        expect(lastOuter).toBe('d');
+
+        // Within base transaction last item is still 'b'
+        const lastBase = await pool.peek(ctxOuter);
+        expect(lastBase).toBe('b');
+      });
+
+      // Now both are committed
+      expect(stack).toEqual(['a', 'b', 'c', 'd']);
+    });
+  });
+
+  describe('in', () => {
+    testRunTxn(txnRunner.in.bind(txnRunner));
+
+    it('reuses existing transaction', async () => {
+      const stack: unknown[] = [];
+      stack.push('a', 'b');
+
+      const pool = openStackPool(stack);
+      const ctxRoot = Context.value(withStackConn, pool);
+
+      await txnRunner.in(ctxRoot, async (ctxOuter, txn) => {
+        await txnRunner.in(ctxOuter, async (ctxInner, txnInner) => {
+          // Same context and txn
+          expect(ctxInner).toBe(ctxOuter);
+          expect(txnInner).toBe(txn);
+
+          await txnInner.push(ctxOuter, 'c');
+
+          // Not yet committed
+          expect(stack).toEqual(['a', 'b']);
+        });
+
+        // Still not committed
+        expect(stack).toEqual(['a', 'b']);
+      });
+
+      // Automatically committed
+      expect(stack).toEqual(['a', 'b', 'c']);
+    });
+  });
+}
+
+describe('explicit accessor', () => {
+  testTxnModes(txn(StackCtxAccessor));
+});
+
+describe('context accessor', () => {
+  const rootCtx = Context.value(withTxnAccessor, StackCtxAccessor);
+
+  testTxnModes(<TxnRunner<StackTxn>>txn(rootCtx));
+
+  it('throws if no accessor on context', () => {
+    expect(() => txn(Context.background)).toThrow('No transaction accessors');
+  });
+});

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -1,0 +1,18 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { IsolationLevel } from '$/types';
+
+describe('IsolationLevel', () => {
+  it('defines isolation levels', () => {
+    expect(IsolationLevel.default).toBe(1);
+    expect(IsolationLevel.readUncommitted).toBe(2);
+    expect(IsolationLevel.readCommitted).toBe(3);
+    expect(IsolationLevel.writeCommitted).toBe(4);
+    expect(IsolationLevel.repeatableRead).toBe(5);
+    expect(IsolationLevel.snapshot).toBe(6);
+    expect(IsolationLevel.serializable).toBe(7);
+    expect(IsolationLevel.linearizable).toBe(8);
+  });
+});


### PR DESCRIPTION
- Defines `Txn`, `Transactable` interfaces
- Implements `ChangeSet`, `TxnChangeSet`
- Implements transaction runners `txn()`, `changeSet()`, `txnChangeSet()`
- Full test coverage using example `StackApi`